### PR TITLE
Prefer OS X package managers.

### DIFF
--- a/index.html
+++ b/index.html
@@ -278,6 +278,7 @@ $ sudo apt-get install mosh</pre>
       <h3 class="callout"><a href="http://www.apple.com"><img class="logo" src="macosx.png" alt=""></a>OS X <small>10.6 or later</small></h3>
       <div class="prelike">Install <a href="https://mosh.mit.edu/mosh-1.2.4-3.pkg"><img src="dmg.png" alt=""> mosh-1.2.4-3.pkg</a>.</div>
       <br />
+      <p><small>This is a standalone OS X package that will work on any supported Macintosh.  However, if you are using a package manager such as Homebrew or MacPorts, we suggest using it to get Mosh, for better compatibility and automatic updates.<small /><p />
     </div>
 
     <div class="span4" style="vertical-align: top;">


### PR DESCRIPTION
A small thing:  The OS X package now installs into /usr/local/bin and might conflict with Homebrew or Fink, and is a bit less stable in general than the package builds.  Tell people to use package managers when possible.

Signed-off-by: John Hood <cgull@glup.org>
